### PR TITLE
fix : #13 차트상세 화면 수정

### DIFF
--- a/design/src/main/kotlin/jinproject/stepwalk/design/component/Button.kt
+++ b/design/src/main/kotlin/jinproject/stepwalk/design/component/Button.kt
@@ -39,7 +39,7 @@ fun DefaultIconButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
 
-    val avoidDuplicationClickEvent = remember(onClick) {
+    val avoidDuplicationClickEvent = remember {
         AvoidDuplicationClickEvent(onClick)
     }
 
@@ -68,7 +68,7 @@ fun DefaultButton(
     contentPaddingValues: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     content: @Composable () -> Unit,
 ) {
-    val avoidDuplicationClickEvent = remember(onClick) {
+    val avoidDuplicationClickEvent = remember {
         AvoidDuplicationClickEvent(onClick)
     }
 
@@ -103,7 +103,7 @@ fun DefaultCombinedButton(
     contentPaddingValues: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
     content: @Composable () -> Unit,
 ) {
-    val avoidDuplicationClickEvent = remember(onClick) {
+    val avoidDuplicationClickEvent = remember {
         AvoidDuplicationClickEvent(onClick)
     }
 

--- a/design/src/main/kotlin/jinproject/stepwalk/design/component/TopBar.kt
+++ b/design/src/main/kotlin/jinproject/stepwalk/design/component/TopBar.kt
@@ -131,18 +131,13 @@ fun StepMateBoxDefaultTopBar(
             .fillMaxWidth()
             .height(48.dp)
     ) {
-        IconButton(
+        DefaultIconButton(
+            modifier = Modifier.size(48.dp)
+                .align(Alignment.CenterStart),
+            icon = icon,
             onClick = onClick,
-            modifier = Modifier
-                .size(48.dp)
-                .align(Alignment.CenterStart)
-        ) {
-            Icon(
-                painter = painterResource(id = icon),
-                contentDescription = "StepMateTopBarIcon",
-                tint = MaterialTheme.colorScheme.onSurface
-            )
-        }
+            iconTint = MaterialTheme.colorScheme.onSurface
+        )
         content()
     }
 }

--- a/design/src/main/res/drawable/ic_check.xml
+++ b/design/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,4 @@
+<vector android:height="24dp" android:viewportHeight="512"
+    android:viewportWidth="512" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M480,128c0,8.19 -3.13,16.38 -9.38,22.62l-256,256C208.4,412.9 200.2,416 192,416s-16.38,-3.13 -22.62,-9.38l-128,-128C35.13,272.4 32,264.2 32,256c0,-18.28 14.95,-32 32,-32c8.19,0 16.38,3.13 22.62,9.38L192,338.8l233.4,-233.4C431.6,99.13 439.8,96 448,96C465.1,96 480,109.7 480,128z"/>
+</vector>

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/CalendarScreen.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/CalendarScreen.kt
@@ -1,26 +1,20 @@
 package jinproject.stepwalk.home.screen.calendar
 
 import android.graphics.Color
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import jinproject.stepwalk.design.component.DefaultButton
 import jinproject.stepwalk.design.component.DefaultLayout
-import jinproject.stepwalk.design.component.DescriptionLargeText
 import jinproject.stepwalk.design.component.StepMateProgressIndicator
 import jinproject.stepwalk.design.component.VerticalSpacer
 import jinproject.stepwalk.design.component.VerticalWeightSpacer
@@ -35,10 +29,8 @@ import jinproject.stepwalk.home.screen.home.component.PopUpState
 import jinproject.stepwalk.home.screen.home.component.tab.chart.addChartPopUpDismiss
 import jinproject.stepwalk.home.screen.home.state.CaloriesMenuFactory
 import jinproject.stepwalk.home.screen.home.state.Day
-import jinproject.stepwalk.home.screen.home.state.Month
 import jinproject.stepwalk.home.screen.home.state.SnackBarMessage
 import jinproject.stepwalk.home.screen.home.state.TimeMenuFactory
-import jinproject.stepwalk.home.screen.home.state.Year
 import kotlin.math.ceil
 import kotlin.math.roundToLong
 
@@ -126,44 +118,8 @@ internal fun OnSuccessCalendarScreen(
             CalendarAppBar(
                 calendarData = calendarData,
                 popBackStack = popBackStack,
-                onDateChange = { prevType ->
-                    setCalendarData(
-                        calendarData.copy(
-                            type = prevType,
-                        )
-                    )
-                }
-            ) {
-                val bool = when (calendarData.type) {
-                    Month -> calendarData.selectedTime.monthValue != 0
-                    Year -> calendarData.selectedTime.year != 0
-                    else -> false
-                }
-                val alpha by animateFloatAsState(
-                    targetValue = if (bool) 1f else 0f,
-                    label = "SelectionButtonAlpha"
-                )
-
-                DefaultButton(
-                    onClick = {
-                        when (calendarData.type) {
-                            Month -> setCalendarData(calendarData.copy(type = Day))
-                            Year -> setCalendarData(calendarData.copy(type = Month))
-                            else -> {}
-                        }
-                    },
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .graphicsLayer {
-                            this.alpha = alpha
-                        }
-                ) {
-                    DescriptionLargeText(
-                        text = "선택",
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
-                }
-            }
+                setCalendarData = setCalendarData,
+            )
         }
     ) {
 
@@ -176,7 +132,8 @@ internal fun OnSuccessCalendarScreen(
 
         CalendarHealthChart(
             graph = uiState.healthTab.graph,
-            header = "시간당 걸음수",
+            header = "걸음수",
+            type = calendarData.type,
             barColor = listOf(
                 StepWalkColor.blue_700.color,
                 StepWalkColor.blue_600.color,
@@ -195,7 +152,8 @@ internal fun OnSuccessCalendarScreen(
             graph = uiState.healthTab.graph.map {
                 ceil(CaloriesMenuFactory.cal(it.toFloat()).toDouble()).roundToLong()
             },
-            header = "시간당 칼로리(Kcal)",
+            header = "칼로리(Kcal)",
+            type = calendarData.type,
             barColor = listOf(
                 StepWalkColor.orange_700.color,
                 StepWalkColor.orange_600.color,
@@ -214,7 +172,8 @@ internal fun OnSuccessCalendarScreen(
             graph = uiState.healthTab.graph.map {
                 TimeMenuFactory.cal(it).roundToLong()
             },
-            header = "시간당 걸은 시간(분)",
+            header = "걸은 시간(분)",
+            type = calendarData.type,
             barColor = listOf(
                 StepWalkColor.green_700.color,
                 StepWalkColor.green_600.color,

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/CalendarAppBar.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/CalendarAppBar.kt
@@ -1,18 +1,33 @@
 package jinproject.stepwalk.home.screen.calendar.component
 
 import android.graphics.Color
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import jinproject.stepwalk.design.R
-import jinproject.stepwalk.design.component.StepMateTitleTopBar
+import jinproject.stepwalk.design.component.AppBarText
+import jinproject.stepwalk.design.component.DefaultIconButton
+import jinproject.stepwalk.design.component.StepMateBoxDefaultTopBar
 import jinproject.stepwalk.design.theme.StepWalkTheme
 import jinproject.stepwalk.home.screen.calendar.CalendarData
 import jinproject.stepwalk.home.screen.home.state.Day
 import jinproject.stepwalk.home.screen.home.state.Month
-import jinproject.stepwalk.home.screen.home.state.Time
 import jinproject.stepwalk.home.screen.home.state.Week
 import jinproject.stepwalk.home.screen.home.state.Year
 
@@ -20,31 +35,76 @@ import jinproject.stepwalk.home.screen.home.state.Year
 internal fun CalendarAppBar(
     calendarData: CalendarData,
     popBackStack: () -> Unit,
-    onDateChange: (Time) -> Unit,
-    content: @Composable BoxScope.() -> Unit = {},
+    setCalendarData: (CalendarData) -> Unit,
 ) {
     val time = calendarData.selectedTime
-    val text = when (calendarData.type) {
+    val type by rememberUpdatedState(newValue = calendarData.type)
+    val text = when (type) {
         Day -> "${time.year}년 ${time.monthValue}월"
         Month -> "${time.year}년"
         Year -> "년도를 선택해 주세요."
         Week -> throw IllegalArgumentException("주단위 달력은 존재 하지 않음.")
     }
-    val prevType = when (calendarData.type) {
+    val prevType = when (type) {
         Day -> Month
         Month -> Year
         Year -> Year
-        Week -> throw IllegalArgumentException("${calendarData.type} 에서는 전환 불가. 년도 까지만 전환 가능")
+        Week -> throw IllegalArgumentException("${calendarData.type} 에서는 전환 불가. (년도 ~ 월) 까지만 전환 가능")
     }
-    StepMateTitleTopBar(
-        modifier = Modifier.clickable(enabled = calendarData.type == Day || calendarData.type == Month) {
-            onDateChange(prevType)
-        },
-        text = text,
+
+    StepMateBoxDefaultTopBar(
+        modifier = Modifier
+            .shadow(4.dp, RectangleShape, clip = false)
+            .background(MaterialTheme.colorScheme.surface)
+            .windowInsetsPadding(WindowInsets.statusBars),
         icon = R.drawable.ic_arrow_left_small,
         onClick = popBackStack,
-        content = content,
-    )
+    ) {
+        AppBarText(
+            text = text,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    enabled = calendarData.type == Day || calendarData.type == Month,
+                    indication = null,
+                ) {
+                    setCalendarData(
+                        calendarData.copy(
+                            type = prevType,
+                        )
+                    )
+                }
+        )
+
+        val bool = when (type) {
+            Month -> calendarData.selectedTime.monthValue != 0
+            Year -> calendarData.selectedTime.year != 0
+            else -> false
+        }
+
+        val alpha by animateFloatAsState(
+            targetValue = if (bool) 1f else 0f,
+            label = "SelectionButtonAlpha"
+        )
+
+        DefaultIconButton(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .graphicsLayer {
+                    this.alpha = alpha
+                },
+            icon = R.drawable.ic_check,
+            onClick = {
+                when (type) {
+                    Month -> setCalendarData(calendarData.copy(type = Day))
+                    Year -> setCalendarData(calendarData.copy(type = Month))
+                    else -> {}
+                }
+            },
+            iconTint = MaterialTheme.colorScheme.onSurface
+        )
+    }
 }
 
 @Composable
@@ -53,6 +113,6 @@ private fun PreviewCalendarAppBar() = StepWalkTheme {
     CalendarAppBar(
         calendarData = CalendarData.getInitValues(),
         popBackStack = {},
-        onDateChange = {},
+        setCalendarData = {},
     )
 }

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/calendar/Month.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/calendar/Month.kt
@@ -70,7 +70,7 @@ internal fun Month(
 private fun PreviewCalendarMonth(
 ) = StepWalkTheme {
     Month(
-        calendarData = CalendarPreviewData.month,
+        calendarData = CalendarPreviewData().month,
         setCalendarData = {}
     )
 }

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/calendar/Year.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/calendar/Year.kt
@@ -68,7 +68,7 @@ internal fun Year(
 private fun PreviewCalendarYear(
 ) = StepWalkTheme {
     Year(
-        calendarData = CalendarPreviewData.year,
+        calendarData = CalendarPreviewData().year,
         setCalendarData = {}
     )
 }

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/chart/CalendarHealthChart.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/component/chart/CalendarHealthChart.kt
@@ -1,7 +1,6 @@
 package jinproject.stepwalk.home.screen.calendar.component.chart
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,11 +14,17 @@ import androidx.compose.ui.unit.dp
 import jinproject.stepwalk.design.component.DescriptionLargeText
 import jinproject.stepwalk.home.screen.home.component.PopUpState
 import jinproject.stepwalk.home.screen.home.component.tab.HealthChart
+import jinproject.stepwalk.home.screen.home.state.Day
+import jinproject.stepwalk.home.screen.home.state.Month
+import jinproject.stepwalk.home.screen.home.state.Time
+import jinproject.stepwalk.home.screen.home.state.Week
+import jinproject.stepwalk.home.screen.home.state.Year
 
 @Composable
 internal fun ColumnScope.CalendarHealthChart(
     graph: List<Long>,
     header: String,
+    type: Time,
     barColor: List<androidx.compose.ui.graphics.Color>,
     popUpState: PopUpState,
     setPopUpState: (PopUpState) -> Unit,
@@ -34,7 +39,12 @@ internal fun ColumnScope.CalendarHealthChart(
             .padding(10.dp),
         header = {
             DescriptionLargeText(
-                text = header,
+                text = when (type) {
+                    Day -> "시간당 "
+                    Month -> "일간 "
+                    Year -> "월간 "
+                    Week -> throw IllegalArgumentException("주간 달력은 존재하지 않음")
+                } + header,
                 modifier = Modifier.padding(vertical = 10.dp)
             )
         },

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/state/CalendarPreviewData.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/calendar/state/CalendarPreviewData.kt
@@ -6,7 +6,7 @@ import jinproject.stepwalk.home.screen.home.state.Month
 import jinproject.stepwalk.home.screen.home.state.Year
 import java.time.ZonedDateTime
 
-internal object CalendarPreviewData : PreviewParameterProvider<CalendarData> {
+internal class CalendarPreviewData : PreviewParameterProvider<CalendarData> {
     private val today = ZonedDateTime.now()
     val month = CalendarData(
         type = Month,

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/HomeScreen.kt
@@ -149,10 +149,11 @@ private fun HomeScreen(
     }
 
     HideableTopBarLayout(
-        modifier = Modifier.addChartPopUpDismiss(
-            popUpState = chartPopUp,
-            setPopUpState = { state -> chartPopUp = state }
-        ),
+        modifier = Modifier
+            .addChartPopUpDismiss(
+                popUpState = chartPopUp,
+                setPopUpState = { state -> chartPopUp = state }
+            ),
         systemBarHidingState = systemBarHidingState,
         topBar = { modifier ->
             HomeTopAppBar(

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/HealthTabLayout.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/HealthTabLayout.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -113,7 +114,11 @@ internal fun ColumnScope.HealthChart(
                     Week.toNumberOfDays() -> (index + 1).weekToString()
                     Day.toNumberOfDays() -> index.toString()
                     else -> (index + 1).toString()
-                }
+                },
+                textAlign = when (graph.size > 14) {
+                    true -> TextAlign.Left
+                    false -> TextAlign.Center
+                },
             )
         },
         verticalAxis = {

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/chart/ChartPopUp.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/chart/ChartPopUp.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.text.drawText
@@ -113,7 +114,7 @@ internal fun Modifier.addChartPopUpDismiss(
     this.pointerInput(popUpState.enabled) {
         awaitPointerEventScope {
             val event = awaitPointerEvent(PointerEventPass.Initial)
-            if (event.changes.any { it.pressed })
+            if (event.type == PointerEventType.Press)
                 setPopUpState(popUpState.copy(enabled = false))
         }
     }

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/chart/HealthChartComponents.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/chart/HealthChartComponents.kt
@@ -25,20 +25,17 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.layout.ParentDataModifier
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import jinproject.stepwalk.design.component.DescriptionSmallText
 import jinproject.stepwalk.design.theme.StepWalkColor
 import jinproject.stepwalk.design.theme.StepWalkTheme
 import jinproject.stepwalk.home.screen.home.HomeUiState
 import jinproject.stepwalk.home.screen.home.HomeUiStatePreviewParameters
 import jinproject.stepwalk.home.screen.home.component.PopUpState
-import kotlin.math.roundToInt
 
 @Composable
 internal fun StepBar(
@@ -92,14 +89,15 @@ internal fun StepBar(
                         cornerRadius = CornerRadius(x = 10f)
                     )
                 }
-            }.then(HealthChartData(graph[index]))
+            }
+            .then(HealthChartData(graph[index]))
     )
 }
 
 @Stable
 internal class HealthChartData(
-    val height: Long
-): ParentDataModifier {
+    val height: Long,
+) : ParentDataModifier {
     override fun Density.modifyParentData(parentData: Any?): Any {
         return this@HealthChartData
     }
@@ -109,12 +107,14 @@ internal class HealthChartData(
 @Composable
 internal fun StepGraphTail(
     item: String,
+    textAlign: TextAlign,
 ) {
-    Text(
+    val startPadding = if (item.length == 1) 3.dp else 0.dp
+
+    DescriptionSmallText(
         text = item,
-        textAlign = TextAlign.Left,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onBackground
+        modifier = Modifier.padding(start = startPadding),
+        textAlign = textAlign,
     )
 }
 

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/chart/HealthChartLayout.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/tab/chart/HealthChartLayout.kt
@@ -102,16 +102,6 @@ internal fun HealthChartLayout(
 
             val eachBarWidth = horizontalPlacables.first().width / horizontalStep
 
-            barDatas.getOrNull(popUpState.index)?.let { data ->
-                val barHeight =
-                    data.stepToSizeByMax(barHeight = barMaxHeight.toFloat(), barMaxData).toInt()
-
-                popUpPlaceable.place(
-                    verticalPlacable.width + eachBarWidth * (popUpState.index),
-                    totalHeight - horizontalPlacables.first().height - barHeight - popUpPlaceable.height - 20
-                )
-            }
-
             barPlaceables.forEachIndexed { index, placeable ->
 
                 if (index % 2 == 0 || itemsCount == horizontalItemCount) {
@@ -125,6 +115,16 @@ internal fun HealthChartLayout(
                 )
 
                 xPos += eachBarWidth
+            }
+
+            barDatas.getOrNull(popUpState.index)?.let { data ->
+                val barHeight =
+                    data.stepToSizeByMax(barHeight = barMaxHeight.toFloat(), barMaxData).toInt()
+
+                popUpPlaceable.place(
+                    verticalPlacable.width + eachBarWidth * (popUpState.index) + eachBarWidth / 2,
+                    totalHeight - horizontalPlacables.first().height - barHeight - popUpPlaceable.height - 20
+                )
             }
         }
     }


### PR DESCRIPTION
### 📌 Issue Number #13

### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 디자인 수정

<br>

### 📙 작업 내역

> 구현 내용 및 작업 내역을 기재합니다.

- 홈화면 내의 차트 popUp이 bar에 가려지지 않도록 수정
- 홈화면의 PopUp이 나타나있을 때 설정창을 눌러 차트상세화면으로 이동되도록 수정
- 차트상세화면에서 달력의 년/월 선택과정에서 선택버튼 말고, 체크모양의 아이콘버튼으로 변경
- 달력의 년/월 선택시 차트의 헤더의 텍스트가 (일단위/월단위)XXX 로 바뀌도록 수정
- 상단바 전체의 onClick이 아닌 상단바의 텍스트부분의 onClick으로 년/월 전환이 되도록 수정
- 차트의 horizontalAxis(시간표시 레이블)와 bar(막대바)의 위치가 안맞는 부분 수정

<br>

### 📋 체크리스트

- [x] PR 제목에 Prefix(Feat, Refactor, Fix...etc) 와 작업 번호 및 내용을 요약 기재
- [x] 사용되지 않은 import 문 제거 & code reformatting 수행
- [x] PR과 관련있는 코드만 추가
- [x] 코드 개선 및 검토 완료

<br>

달력부분 수평드래그로 넘어가는건 애니메이션 없어도 괜찮아보이는데 그냥 그대로 두고 넘어갈까?

<br/><br/>
