### PR TITLE
fix : 홈화면 핫픽스

### DIFF
--- a/app/src/main/kotlin/jinproject/stepwalk/app/ui/NetworkState.kt
+++ b/app/src/main/kotlin/jinproject/stepwalk/app/ui/NetworkState.kt
@@ -1,8 +1,0 @@
-package jinproject.stepwalk.app.ui
-
-sealed interface NetworkState {
-    data object Loading: NetworkState
-    data object Success: NetworkState
-
-    data class Fail(val e: Throwable): NetworkState
-}

--- a/app/src/main/kotlin/jinproject/stepwalk/app/ui/StepMateViewModel.kt
+++ b/app/src/main/kotlin/jinproject/stepwalk/app/ui/StepMateViewModel.kt
@@ -1,71 +1,42 @@
 package jinproject.stepwalk.app.ui
 
-import android.Manifest
-import android.app.AlarmManager
 import android.content.Context
-import android.content.pm.PackageManager
 import android.os.Build
-import androidx.core.content.ContextCompat
-import androidx.health.connect.client.permission.HealthPermission
-import androidx.health.connect.client.records.StepsRecord
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import jinproject.stepwalk.app.ui.navigation.permission.PermissionRequester
 import jinproject.stepwalk.home.HealthConnector
-import kotlinx.coroutines.flow.MutableSharedFlow
+import jinproject.stepwalk.home.HealthConnector.Companion.healthConnectPermissions
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 internal class StepMateViewModel @Inject constructor(
     @ApplicationContext private val applicationContext: Context,
     private val healthConnector: HealthConnector,
-): ViewModel() {
-    private val _state = MutableSharedFlow<NetworkState>()
-    val state get() = _state.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = NetworkState.Loading
-    )
+) : ViewModel() {
 
     private val _permissionState = MutableStateFlow(false)
     val permissionState get() = _permissionState.asStateFlow()
 
-    fun setNetworkState(state: NetworkState) {
-        viewModelScope.launch {
-            _state.emit(state)
-        }
-    }
-
     suspend fun checkPermission() {
-        val isNotificationGranted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && ContextCompat.checkSelfPermission(
-            applicationContext,
-            Manifest.permission.POST_NOTIFICATIONS
-        ) == PackageManager.PERMISSION_GRANTED
+        val isNotificationGranted =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                PermissionRequester.checkNotification(applicationContext)
+            else
+                true
 
-        val isActivityRecognitionGranted = ContextCompat.checkSelfPermission(applicationContext, Manifest.permission.ACTIVITY_RECOGNITION)== PackageManager.PERMISSION_GRANTED
+        val isActivityRecognitionGranted =
+            PermissionRequester.checkActivityRecognition(applicationContext)
 
-        val healthDataTypes = setOf(
-            StepsRecord::class,
-        )
-
-        val healthConnectPermissions: Set<String> =
-            healthDataTypes.map {
-                HealthPermission.getReadPermission(it)
-            }.toMutableSet().apply {
-                addAll(healthDataTypes.map { HealthPermission.getWritePermission(it) })
-            }.toSet()
-
-        val alarmManager =
-            applicationContext.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-
-        val isExactAlarmGranted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && alarmManager.canScheduleExactAlarms()
+        val isExactAlarmGranted =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+                PermissionRequester.checkExactAlarm(applicationContext)
+            else
+                true
 
         val isHealthConnectGranted = healthConnector.checkPermissions(healthConnectPermissions)
 

--- a/app/src/main/kotlin/jinproject/stepwalk/app/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/kotlin/jinproject/stepwalk/app/ui/navigation/NavigationGraph.kt
@@ -14,6 +14,8 @@ import androidx.navigation.NavDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navOptions
+import jinproject.stepwalk.app.ui.navigation.permission.PermissionScreen
+import jinproject.stepwalk.app.ui.navigation.permission.permissionRoute
 import jinproject.stepwalk.core.SnackBarMessage
 import jinproject.stepwalk.home.navigation.homeNavGraph
 import jinproject.stepwalk.home.navigation.navigateToCalendar
@@ -129,40 +131,39 @@ internal fun NavigationSuiteScope.stepMateNavigationSuiteItems(
     itemColors: NavigationSuiteItemColors,
     onClick: (NavigationDestination) -> Unit,
 ) {
-    if (currentDestination.isShownBar())
-        NavigationDestination.entries.forEach { destination ->
-            val selected = currentDestination.isDestinationInHierarchy(destination)
+    NavigationDestination.entries.forEach { destination ->
+        val selected = currentDestination.isDestinationInHierarchy(destination)
 
-            item(
-                selected = selected,
-                onClick = { onClick(destination) },
-                icon = {
-                    if (!selected)
-                        Icon(
-                            imageVector = ImageVector.vectorResource(id = destination.icon),
-                            contentDescription = "clickIcon",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                    else
-                        Icon(
-                            imageVector = ImageVector.vectorResource(id = destination.iconClicked),
-                            contentDescription = "clickedIcon",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                },
-                colors = itemColors,
-            )
-        }
+        item(
+            selected = selected,
+            onClick = { onClick(destination) },
+            icon = {
+                if (!selected)
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = destination.icon),
+                        contentDescription = "clickIcon",
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                else
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = destination.iconClicked),
+                        contentDescription = "clickedIcon",
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+            },
+            colors = itemColors,
+        )
+    }
 }
 
 @Immutable
 internal object NavigationDefaults {
     @Composable
-    fun navigationIndicatorColor() = MaterialTheme.colorScheme.background
+    fun navigationIndicatorColor() = MaterialTheme.colorScheme.surface
 
     @Composable
-    fun containerColor() = MaterialTheme.colorScheme.background
+    fun containerColor() = MaterialTheme.colorScheme.surface
 
     @Composable
-    fun contentColor() = MaterialTheme.colorScheme.onBackground
+    fun contentColor() = MaterialTheme.colorScheme.onSurface
 }

--- a/app/src/main/kotlin/jinproject/stepwalk/app/ui/navigation/permission/PermissionRequester.kt
+++ b/app/src/main/kotlin/jinproject/stepwalk/app/ui/navigation/permission/PermissionRequester.kt
@@ -1,0 +1,38 @@
+package jinproject.stepwalk.app.ui.navigation.permission
+
+import android.Manifest
+import android.app.AlarmManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+
+object PermissionRequester {
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    fun checkNotification(context: Context): Boolean {
+        val result = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS
+        )
+
+        return result == PackageManager.PERMISSION_GRANTED
+    }
+
+    fun checkActivityRecognition(context: Context): Boolean {
+        val result = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACTIVITY_RECOGNITION
+        )
+
+        return result == PackageManager.PERMISSION_GRANTED
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    fun checkExactAlarm(context: Context) : Boolean {
+        val alarmManager =
+            context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        return alarmManager.canScheduleExactAlarms()
+    }
+}

--- a/app/src/main/kotlin/jinproject/stepwalk/app/ui/navigation/permission/PermissionScreen.kt
+++ b/app/src/main/kotlin/jinproject/stepwalk/app/ui/navigation/permission/PermissionScreen.kt
@@ -1,4 +1,4 @@
-package jinproject.stepwalk.app.ui.navigation
+package jinproject.stepwalk.app.ui.navigation.permission
 
 import android.Manifest
 import android.app.AlarmManager
@@ -48,6 +48,7 @@ import jinproject.stepwalk.design.component.VerticalSpacer
 import jinproject.stepwalk.design.component.clickableAvoidingDuplication
 import jinproject.stepwalk.design.component.layout.DefaultLayout
 import jinproject.stepwalk.design.theme.StepWalkTheme
+import jinproject.stepwalk.home.HealthConnector.Companion.healthConnectPermissions
 
 internal const val permissionRoute = "permission"
 
@@ -76,7 +77,6 @@ internal fun PermissionScreen(
 
     PermissionScreen(
         healthConnectPermissionContract = permissionViewModel::healthConnectPermissionContract.get(),
-        healthConnectPermissions = permissionViewModel::healthConnectPermissions.get(),
         requireInstallHealthApk = permissionViewModel::requireInstallHealthApk,
         showSnackBar = showSnackBar,
         notificationPermission = notificationPermission,
@@ -94,7 +94,6 @@ internal fun PermissionScreen(
 private fun PermissionScreen(
     context: Context = LocalContext.current,
     healthConnectPermissionContract: ActivityResultContract<Set<String>, Set<String>>,
-    healthConnectPermissions: Set<String>,
     requireInstallHealthApk: () -> Unit,
     showSnackBar: (SnackBarMessage) -> Unit,
     notificationPermission: Boolean,
@@ -340,7 +339,6 @@ internal fun PermissionDescription(
 private fun PreviewPermissionScreen() = StepWalkTheme {
     PermissionScreen(
         healthConnectPermissionContract = PermissionController.createRequestPermissionResultContract(),
-        healthConnectPermissions = setOf(),
         showSnackBar = {},
         notificationPermission = true,
         activityRecognitionPermission = false,

--- a/data/src/main/kotlin/jinproject/stepwalk/data/di/Retrofit.kt
+++ b/data/src/main/kotlin/jinproject/stepwalk/data/di/Retrofit.kt
@@ -27,6 +27,7 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
 import java.io.IOException
 import java.lang.reflect.Type
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -64,6 +65,9 @@ internal object RetrofitWithTokenModule {
             .addInterceptor(HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.BODY
             })
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .writeTimeout(20, TimeUnit.SECONDS)
             .addInterceptor(headerInterceptor)
             .build()
     }

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/HealthConnector.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/HealthConnector.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.aggregate.AggregateMetric
+import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.metadata.DataOrigin
@@ -288,5 +289,16 @@ class HealthConnector @Inject constructor(
                 put(HealthCareExtras.KEY_HEART_RATE_MIN, HeartRateRecord.BPM_MIN)
                 put(HealthCareExtras.KEY_HEART_RATE_AVG, HeartRateRecord.BPM_AVG)
             }
+
+        private val healthDataTypes = setOf(
+            StepsRecord::class,
+        )
+
+        val healthConnectPermissions: Set<String> =
+            healthDataTypes.map {
+                HealthPermission.getReadPermission(it)
+            }.toMutableSet().apply {
+                addAll(healthDataTypes.map { HealthPermission.getWritePermission(it) })
+            }.toSet()
     }
 }

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/HomeScreen.kt
@@ -60,6 +60,7 @@ internal fun HomeScreen(
 ) {
     val uiState by homeViewModel.uiState.collectAsStateWithLifecycle()
     val time by homeViewModel.time.collectAsStateWithLifecycle()
+    val userName by homeViewModel.userName.collectAsStateWithLifecycle()
 
     LifecycleEventEffect(event = Lifecycle.Event.ON_CREATE) {
         context.startForegroundService(Intent(context, StepService::class.java))
@@ -107,6 +108,7 @@ internal fun HomeScreen(
 
     HomeScreen(
         uiState = uiState,
+        userName = userName,
         setTimeOnGraph = homeViewModel::setTime,
         navigateToCalendar = navigateToCalendar,
         navigateToHomeSetting = navigateToHomeSetting,
@@ -116,6 +118,7 @@ internal fun HomeScreen(
 @Composable
 private fun HomeScreen(
     uiState: HomeUiState,
+    userName: String,
     context: Context = LocalContext.current,
     density: Density = LocalDensity.current,
     setTimeOnGraph: (Time) -> Unit,
@@ -158,6 +161,7 @@ private fun HomeScreen(
                         modifier = Modifier
                             .padding(bottom = 10.dp, start = 12.dp, end = 12.dp),
                         step = uiState.step,
+                        userName = userName,
                     )
                 }
             )
@@ -201,6 +205,7 @@ private fun PreviewHomeScreen(
 ) = StepWalkTheme {
     HomeScreen(
         uiState = homeUiState,
+        userName = "",
         setTimeOnGraph = {},
         navigateToCalendar = {},
         navigateToHomeSetting = {},

--- a/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/userinfo/UserInfoLayout.kt
+++ b/feature/home/src/main/kotlin/jinproject/stepwalk/home/screen/home/component/userinfo/UserInfoLayout.kt
@@ -20,6 +20,7 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import jinproject.stepwalk.design.component.DescriptionLargeText
+import jinproject.stepwalk.design.component.DescriptionSmallText
 import jinproject.stepwalk.design.component.FooterText
 import jinproject.stepwalk.design.component.HorizontalWeightSpacer
 import jinproject.stepwalk.design.component.VerticalWeightSpacer
@@ -34,6 +35,7 @@ import jinproject.stepwalk.home.screen.home.state.HealthTab
 @Composable
 internal fun UserInfoLayout(
     modifier: Modifier = Modifier,
+    userName: String = "",
     step: HealthTab,
 ) {
     val progress = (step.header.total.toFloat() / step.header.goal.toFloat()).coerceIn(0f, 1f)
@@ -54,7 +56,7 @@ internal fun UserInfoLayout(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(28.dp),
-            name = "홍길동",
+            name = userName,
         )
         VerticalWeightSpacer(float = 1f)
         StepLayout(
@@ -105,12 +107,15 @@ internal fun UserStatus(
         Column(
             modifier = Modifier
         ) {
-            Row(
-                verticalAlignment = Alignment.Bottom,
-            ) {
-                DescriptionLargeText(text = name)
-                FooterText(text = "님")
-            }
+            if (name.isNotBlank())
+                Row(
+                    verticalAlignment = Alignment.Bottom,
+                ) {
+                    DescriptionLargeText(text = name)
+                    FooterText(text = "님")
+                }
+            else
+                DescriptionSmallText(text = "StepMate 를 이용해 주셔서 감사해요.")
             FooterText(text = "오늘도 즐거운 하루 되세요!", modifier = Modifier.padding(start = 2.dp))
         }
         HorizontalWeightSpacer(float = 1f)


### PR DESCRIPTION
### 📌 Issue Number

### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 디자인 수정

<br>

### 📙 작업 내역

> 구현 내용 및 작업 내역을 기재합니다.

- NavigationSuiteScaffold가 내부 surface에 tonalElevation 을 파라미터로 받지 않아서 CompositionLocals 의 TonalElevatedEnabled 를 false 로 provide 해서 Colorscheme.surface 가 재대로 설정되지 않았던 부분 수정
- NavigationSuiteScaffold 에서 navigation 상에서 바텀바가 표시되지 않아야 하는곳에서 표시되지 않도록 수정
- 네트워크 I/O 와 연결의 timeout을 변경 (기존10 -> 30/20/20)
- 권한을 요청하는 로직들을 하나의 유틸 오브젝트로 모아서 관리하도록 수정
- 홈화면에서 로그인한 유저의 이름이 표시되지 않던부분 수정
- 포그라운드 서비스에서 걸음수를 저장할 때 로그인 하지 않았다면 서버로 보내지 않도록 수정

<br>

### 📋 체크리스트

- [x] PR 제목에 Prefix(Feat, Refactor, Fix...etc) 와 작업 번호 및 내용을 요약 기재
- [x] 사용되지 않은 import 문 제거 & code reformatting 수행
- [x] PR과 관련있는 코드만 추가
- [x] 코드 개선 및 검토 완료

<br>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점으로 없을 경우 제거 이후 PR을 생성합니다.

- Surface 컴포넌트는 Material Design 철학에 따라서 내부적으로 color 파라미터가 Colorscheme.Surface 이고,  tonalElevation 이 0이 아니면서, CompositionLocals 의 TonalElevatedEnabled 가 true 라면, 내부적으로 surface 색상에 tonalElevation 으로 변형을 줘서 1~5단계로 바꾸고 있어. 근데 폴더블 대응을 위해서 추가했던 Material3-adaptive 의 SuiteScaffold 가 TonalElevation 을 2.0 이라는 값으로 고정해버려서 우리가 약속했던 상&하단바의 색상은 surface 로 고정하자고 했던걸 지키려고 CompositionLocals 의 TonalElevatedEnabled 을 false 로 줘서 해결했어

<br/><br/>
