### PR TITLE
fix : 걸음수 로직, 랭킹 화면 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("stepMate.android.application")
     id("stepMate.android.compose")
     id("stepMate.android.parcelize")
+    id("stepMate.android.gms-services")
 }
 
 android {

--- a/design/src/main/kotlin/com/stepmate/design/component/lazyList/TimeScheduler.kt
+++ b/design/src/main/kotlin/com/stepmate/design/component/lazyList/TimeScheduler.kt
@@ -49,22 +49,26 @@ class TimeScheduler(
             scheduledTime -= 1000L
         }
         callBack()
+        job = null
     }
 
     fun setTime(minimumExecutingTime: Long = STANDARD_MILLIS) {
         scheduledTime = minimumExecutingTime
 
-        if (job == null) {
-            job = execute()
+        job = if (job == null) {
+            execute()
         } else {
-            if (!job!!.isActive)
-                job = execute()
+            if (job!!.isActive)
+                job!!.cancel()
+
+            execute()
         }
     }
 
     fun cancel() {
         if (job != null && job!!.isActive) {
             job!!.cancel()
+            job = null
             scheduledTime = 0
         }
     }

--- a/feature/home/src/main/kotlin/com/stepmate/home/service/StepService.kt
+++ b/feature/home/src/main/kotlin/com/stepmate/home/service/StepService.kt
@@ -79,7 +79,7 @@ internal class StepService : LifecycleService() {
             stepSensorManager = StepSensorManager(
                 context = this@StepService,
                 onSensorChanged = { event ->
-                    lifecycleScope.launch(serviceDispatcher) {
+                    launch(serviceDispatcher) {
                         val stepBySensor = event?.values?.first()?.toLong() ?: 0L
                         stepSensorViewModel.onSensorChanged(stepBySensor)
                     }
@@ -108,6 +108,7 @@ internal class StepService : LifecycleService() {
                                         StepException.NEED_RE_LOGIN,
                                         StepException.NEED_RE_LOGIN
                                     )
+                                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
                                 })
                         }
 

--- a/feature/ranking/src/main/kotlin/com/stepmate/ranking/rank/component/RankTop3.kt
+++ b/feature/ranking/src/main/kotlin/com/stepmate/ranking/rank/component/RankTop3.kt
@@ -1,5 +1,6 @@
 package com.stepmate.ranking.rank.component
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -15,7 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -26,19 +28,16 @@ import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.stepmate.core.getCharacter
 import com.stepmate.design.R
-import com.stepmate.design.appendFontSizeWithColorText
 import com.stepmate.design.component.DefaultIconButton
-import com.stepmate.design.component.DescriptionAnnotatedSmallText
 import com.stepmate.design.component.DescriptionLargeText
+import com.stepmate.design.component.DescriptionSmallText
 import com.stepmate.design.component.DialogState
 import com.stepmate.design.component.FooterText
 import com.stepmate.design.component.HorizontalSpacer
-import com.stepmate.design.component.HorizontalWeightSpacer
 import com.stepmate.design.component.VerticalSpacer
 import com.stepmate.design.component.clickableAvoidingDuplication
-import com.stepmate.design.theme.StepWalkColor
 import com.stepmate.design.theme.StepMateTheme
-import com.stepmate.design.tu
+import com.stepmate.design.theme.StepWalkColor
 import com.stepmate.ranking.rank.Rank
 import com.stepmate.ranking.rank.RankBoard
 import com.stepmate.ranking.rank.state.RankBoardPreviewParameter
@@ -103,34 +102,32 @@ internal fun RankTop3(
         VerticalSpacer(height = 20.dp)
 
         Row(
-            modifier = Modifier.fillMaxWidth().height(120.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(134.dp),
             verticalAlignment = Alignment.Bottom,
         ) {
-            HorizontalWeightSpacer(float = 1f)
             if (rankBoard.top3.getOrNull(1) != null)
                 Ranker(
-                    modifier = Modifier.height(100.dp),
+                    modifier = Modifier.height(114.dp),
                     rank = rankBoard.top3[1],
                     maxStep = rankBoard.highestStep,
                     navigateToRankingUserDetail = navigateToRankingUserDetail,
                 )
-            HorizontalWeightSpacer(float = 1f)
             if (rankBoard.top3.getOrNull(0) != null)
                 Ranker(
-                    modifier = Modifier.height(120.dp),
+                    modifier = Modifier.height(134.dp),
                     rank = rankBoard.top3[0],
                     maxStep = rankBoard.highestStep,
                     navigateToRankingUserDetail = navigateToRankingUserDetail,
                 )
-            HorizontalWeightSpacer(float = 1f)
             if (rankBoard.top3.getOrNull(2) != null)
                 Ranker(
-                    modifier = Modifier.height(100.dp),
+                    modifier = Modifier.height(114.dp),
                     rank = rankBoard.top3[2],
                     maxStep = rankBoard.highestStep,
                     navigateToRankingUserDetail = navigateToRankingUserDetail,
                 )
-            HorizontalWeightSpacer(float = 1f)
         }
     }
 }
@@ -141,20 +138,24 @@ private fun Ranker(
     rank: Rank,
     maxStep: Int,
     navigateToRankingUserDetail: (String, Int) -> Unit,
+    configuration: Configuration = LocalConfiguration.current,
 ) {
     val composition by rememberLottieComposition(LottieCompositionSpec.Asset(getCharacter(rank.level)))
     val lottieProgress by animateLottieCompositionAsState(
         composition,
         iterations = LottieConstants.IterateForever
     )
+    val itemWidth = ((configuration.screenWidthDp - 32) / 3).dp
 
     Column(
-        modifier = modifier.clickableAvoidingDuplication {
-            navigateToRankingUserDetail(
-                rank.name,
-                maxStep,
-            )
-        },
+        modifier = modifier
+            .width(itemWidth)
+            .clickableAvoidingDuplication {
+                navigateToRankingUserDetail(
+                    rank.name,
+                    maxStep,
+                )
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Row {
@@ -174,15 +175,12 @@ private fun Ranker(
                 .size(48.dp)
         )
         VerticalSpacer(height = 4.dp)
-        val text = buildAnnotatedString {
-            appendFontSizeWithColorText(
-                text = rank.designation,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 8.tu,
-            )
-            append(" ${rank.name}")
-        }
-        DescriptionAnnotatedSmallText(text = text)
+        FooterText(
+            text = rank.designation,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        VerticalSpacer(height = 4.dp)
+        DescriptionSmallText(text = rank.name)
         VerticalSpacer(height = 4.dp)
         FooterText(text = rank.step.toString())
     }
@@ -194,13 +192,15 @@ private fun PreviewRankTop3(
     @PreviewParameter(RankBoardPreviewParameter::class)
     rankBoard: RankBoard,
 ) = StepMateTheme {
-    RankTop3(
-        title = "월간 랭킹",
-        rankBoard = rankBoard,
-        dialogState = DialogState.getInitValue(),
-        setDialogState = {},
-        navigateToRankingUserDetail = { _, _ -> },
-    )
+    Column(Modifier.padding(horizontal = 16.dp)) {
+        RankTop3(
+            title = "월간 랭킹",
+            rankBoard = rankBoard,
+            dialogState = DialogState.getInitValue(),
+            setDialogState = {},
+            navigateToRankingUserDetail = { _, _ -> },
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
### 📌 Issue Number

### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 디자인 수정

<br>

### 📙 작업 내역

> 구현 내용 및 작업 내역을 기재합니다.

- 바뀐 패키지명에 해당하는 크래시리틱스 추가
- 랭킹화면의 Top3 가 이름, 칭호의 길이에 의해 한쪽으로 기울어지던 부분 수정
- 걸음수 타이머에서 내부 변수 job 이 생성된 코루틴의 job을 가지도록 구현했는데, 센서에 의해 걸음수가 수집될 때 마다 기존의 job 을 취소하지 않고 할당해서 실제로는 코루틴이 중복해서 계속 생성되면서 어떤 코루틴이 먼저 완료될지 모르기 때문에 일정 걸음수가 누락될수 있는 문제가 있었고 기존의 job 을 취소한뒤, 할당하도록 변경


<br>

### 📋 체크리스트

- [x] PR 제목에 Prefix(Feat, Refactor, Fix...etc) 와 작업 번호 및 내용을 요약 기재
- [x] 사용되지 않은 import 문 제거 & code reformatting 수행
- [x] PR과 관련있는 코드만 추가
- [x] 코드 개선 및 검토 완료

<br/><br/>
