### PR TITLE
fix : 잘못된 권한 대응 수정

### DIFF
--- a/app/src/main/kotlin/com/stepmate/app/StepMateActivity.kt
+++ b/app/src/main/kotlin/com/stepmate/app/StepMateActivity.kt
@@ -1,7 +1,6 @@
 package com.stepmate.app
 
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.View
 import android.view.ViewTreeObserver
@@ -37,13 +36,11 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.findNavController
 import com.stepmate.app.ui.StepMateViewModel
 import com.stepmate.app.ui.navigation.NavigationDefaults
 import com.stepmate.app.ui.navigation.NavigationGraph
 import com.stepmate.app.ui.navigation.Router
 import com.stepmate.app.ui.navigation.isShownBar
-import com.stepmate.app.ui.navigation.permission.PermissionViewModel
 import com.stepmate.app.ui.navigation.stepMateNavigationSuiteItems
 import com.stepmate.design.component.StepMateSnackBar
 import com.stepmate.design.theme.StepMateTheme
@@ -93,22 +90,6 @@ class StepMateActivity : ComponentActivity() {
         isNeedReLogin?.let {
             stepMateViewModel.updateIsNeedLogin(true)
         }
-    }
-
-    @Deprecated("Deprecated in Java")
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray,
-    ) {
-        when (requestCode) {
-            PermissionViewModel.ACTIVITY_RECOGNITION_CODE ->
-                stepMateViewModel.updateActivityRecognition(grantResults.first() == PackageManager.PERMISSION_GRANTED)
-
-            PermissionViewModel.HEALTH_CONNECT_CODE ->
-                stepMateViewModel.updateHealthConnect(grantResults.all { r -> r == PackageManager.PERMISSION_GRANTED })
-        }
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     @OptIn(

--- a/app/src/main/kotlin/com/stepmate/app/ui/StepMateViewModel.kt
+++ b/app/src/main/kotlin/com/stepmate/app/ui/StepMateViewModel.kt
@@ -27,26 +27,6 @@ internal class StepMateViewModel @Inject constructor(
 
     fun updateIsNeedLogin(bool: Boolean) = _isNeedReLogin.update { bool }
 
-    fun updateActivityRecognition(bool: Boolean) {
-        _startDestinationInfo.update { info ->
-            info.copy(
-                underApi31HasPermission = info.underApi31HasPermission.copy(
-                    isActivityRecognitionGranted = bool
-                )
-            )
-        }
-    }
-
-    fun updateHealthConnect(bool: Boolean) {
-        _startDestinationInfo.update { info ->
-            info.copy(
-                underApi31HasPermission = info.underApi31HasPermission.copy(
-                    isHealthConnectGranted = bool
-                )
-            )
-        }
-    }
-
     private val _startDestinationInfo = MutableStateFlow(StartDestinationInfo())
 
     val startDestinationInfo = _startDestinationInfo.asStateFlow()
@@ -56,20 +36,11 @@ internal class StepMateViewModel @Inject constructor(
     }.first()
 
     suspend fun checkPermission() {
-        val isNotificationGranted =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-                PermissionRequester.checkNotification(applicationContext)
-            else
-                true
+        val permissionResults = PermissionRequester.checkAllPermissions(applicationContext)
 
-        val isActivityRecognitionGranted =
-            PermissionRequester.checkActivityRecognition(applicationContext)
-
-        val isExactAlarmGranted =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-                PermissionRequester.checkExactAlarm(applicationContext)
-            else
-                true
+        val isNotificationGranted = permissionResults.notification
+        val isActivityRecognitionGranted = permissionResults.activityRecognition
+        val isExactAlarmGranted = permissionResults.exactAlarm
 
         val isHealthConnectGranted = runCatching {
             healthConnector.checkPermissions(HealthConnector.healthConnectPermissions)
@@ -87,10 +58,4 @@ internal class StepMateViewModel @Inject constructor(
 data class StartDestinationInfo(
     val hasPermission: Boolean = false,
     val hasBodyData: Boolean = false,
-    val underApi31HasPermission: UnderApi31Permission = UnderApi31Permission(),
-)
-
-data class UnderApi31Permission(
-    val isActivityRecognitionGranted: Boolean = false,
-    val isHealthConnectGranted: Boolean = false,
 )

--- a/app/src/main/kotlin/com/stepmate/app/ui/navigation/NavigationGraph.kt
+++ b/app/src/main/kotlin/com/stepmate/app/ui/navigation/NavigationGraph.kt
@@ -61,7 +61,6 @@ internal fun NavigationGraph(
         modifier = modifier
     ) {
         permissionNavGraph(
-            underApi31Permission = startDestinationInfo.underApi31HasPermission,
             paddingValues = paddingValues,
             showSnackBar = showSnackBar,
             navigateToHomeGraph = navController::navigateToHomeGraph,

--- a/app/src/main/kotlin/com/stepmate/app/ui/navigation/permission/PermissionNavigation.kt
+++ b/app/src/main/kotlin/com/stepmate/app/ui/navigation/permission/PermissionNavigation.kt
@@ -8,7 +8,6 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navOptions
 import androidx.navigation.navigation
-import com.stepmate.app.ui.UnderApi31Permission
 import com.stepmate.app.ui.navigation.permission.PermissionRoute.permissionGraph
 import com.stepmate.app.ui.navigation.permission.PermissionRoute.permissionRoute
 import com.stepmate.core.SnackBarMessage
@@ -19,7 +18,6 @@ object PermissionRoute {
 }
 
 fun NavGraphBuilder.permissionNavGraph(
-    underApi31Permission: UnderApi31Permission,
     paddingValues: PaddingValues,
     showSnackBar: (SnackBarMessage) -> Unit,
     navigateToHomeGraph: (NavOptions?) -> Unit,
@@ -30,7 +28,6 @@ fun NavGraphBuilder.permissionNavGraph(
     ) {
         composable(route = permissionRoute) {
             PermissionScreen(
-                underApi31Permission = underApi31Permission,
                 modifier = Modifier.padding(paddingValues),
                 showSnackBar = showSnackBar,
                 navigateToHomeGraph = {

--- a/app/src/main/kotlin/com/stepmate/app/ui/navigation/permission/PermissionRequester.kt
+++ b/app/src/main/kotlin/com/stepmate/app/ui/navigation/permission/PermissionRequester.kt
@@ -29,10 +29,39 @@ object PermissionRequester {
     }
 
     @RequiresApi(Build.VERSION_CODES.S)
-    fun checkExactAlarm(context: Context) : Boolean {
+    fun checkExactAlarm(context: Context): Boolean {
         val alarmManager =
             context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
         return alarmManager.canScheduleExactAlarms()
+    }
+
+    class PermissionResults(
+        val notification: Boolean = false,
+        val activityRecognition: Boolean = false,
+        val exactAlarm: Boolean = false,
+    )
+
+    fun checkAllPermissions(applicationContext: Context): PermissionResults {
+        val isNotificationGranted =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                checkNotification(applicationContext)
+            else
+                true
+
+        val isActivityRecognitionGranted =
+            checkActivityRecognition(applicationContext)
+
+        val isExactAlarmGranted =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+                checkExactAlarm(applicationContext)
+            else
+                true
+
+        return PermissionResults(
+            notification = isNotificationGranted,
+            activityRecognition = isActivityRecognitionGranted,
+            exactAlarm = isExactAlarmGranted,
+        )
     }
 }

--- a/feature/home/src/main/kotlin/com/stepmate/home/HealthConnector.kt
+++ b/feature/home/src/main/kotlin/com/stepmate/home/HealthConnector.kt
@@ -61,10 +61,6 @@ class HealthConnector @Inject constructor(
             ?.containsAll(permissions) ?: false
     }
 
-    fun requestPermissionsActivityContract(): ActivityResultContract<Set<String>, Set<String>> {
-        return PermissionController.createRequestPermissionResultContract()
-    }
-
     private fun getHealthClient(): HealthConnectClient? =
         if (checkAvailability() == HealthConnectClient.SDK_AVAILABLE) {
             HealthConnectClient.getOrCreate(context)
@@ -163,7 +159,9 @@ class HealthConnector @Inject constructor(
         factory = StepFactory.instance
     )
 
-    internal suspend fun getTodayTotalStep(): Long = getSpecificDayTotalStep(Instant.now().epochSecond)
+    internal suspend fun getTodayTotalStep(): Long =
+        getSpecificDayTotalStep(Instant.now().epochSecond)
+
     internal suspend fun getSpecificDayTotalStep(epochSecond: Long): Long = kotlin.run {
         val instant = Instant
             .ofEpochSecond(epochSecond)
@@ -303,5 +301,9 @@ class HealthConnector @Inject constructor(
             }.toMutableSet().apply {
                 addAll(healthDataTypes.map { HealthPermission.getWritePermission(it) })
             }.toSet()
+
+        fun requestPermissionsActivityContract(): ActivityResultContract<Set<String>, Set<String>> {
+            return PermissionController.createRequestPermissionResultContract()
+        }
     }
 }


### PR DESCRIPTION
### 📌 Issue Number

### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 디자인 수정

<br>

### 📙 작업 내역

> 구현 내용 및 작업 내역을 기재합니다.

- api 30 이하에서 Activity. onRequestPermissionsResult 를 오버라이딩 하여 권한 요청의 결과를 처리하는 방법이 deprecation 되었기 때문에 31 부터는 ActivityResult*** 를 이용하여 권한 또는 화면을 요청을 하게 되는데, 해당 부분을 잘못 이해하여 하위버전을 위해서 하위버전인 경우 onRequestPermissionsResult 를 오버라이딩 하여 처리해야 한다고 생각하고 작업했던 부분을 수정
- 내부적으로 권한 또는 화면 요청의 로직이 ActivityCompat 의 함수로 처리되기 때문에 개발자가 신경써야 할 부분이 없음
- 따라서, ActivityResultLauncher, ActivityResultContract 를 이용하여 권한을 처리하고 compose 용도로 지원하는 androidx.activity.compose.ActivityResultRegistry.kt 의 함수들을 이용하면 됨

<br>

### 📋 체크리스트

- [x] PR 제목에 Prefix(Feat, Refactor, Fix...etc) 와 작업 번호 및 내용을 요약 기재
- [x] 사용되지 않은 import 문 제거 & code reformatting 수행
- [x] PR과 관련있는 코드만 추가
- [x] 코드 개선 및 검토 완료

<br/><br/>
